### PR TITLE
Pass the current Grammar as parameter to devdocs.io

### DIFF
--- a/lib/devdocs.js
+++ b/lib/devdocs.js
@@ -7,7 +7,8 @@ module.exports = {
 
     search: function() {
         var wordToSearchFor = atom.workspace.getActiveTextEditor().getSelectedText() || atom.workspace.getActiveTextEditor().getWordUnderCursor();
+        var grammar = atom.workspace.getActiveTextEditor().getGrammar().name;
         var shell = require('shell');
-        shell.openExternal("http://devdocs.io/#q=" + wordToSearchFor);
+        shell.openExternal("http://devdocs.io/#q=" + grammar + " " + wordUnderCursor);
     }
 };


### PR DESCRIPTION
The original version will open devdocs.io only with the current word or text selected but did not pass the language (grammar). I did tests on Javascript, PHP and Python and it works perfectly with this fix.
