### PR TITLE
Erased searching with grammar

### DIFF
--- a/lib/devdocs.js
+++ b/lib/devdocs.js
@@ -7,8 +7,7 @@ module.exports = {
 
     search: function() {
         var wordToSearchFor = atom.workspace.getActiveTextEditor().getSelectedText() || atom.workspace.getActiveTextEditor().getWordUnderCursor();
-        var grammar = atom.workspace.getActiveTextEditor().getGrammar().name;
         var shell = require('shell');
-        shell.openExternal("http://devdocs.io/#q=" + grammar + " " + wordUnderCursor);
+        shell.openExternal("http://devdocs.io/#q=" + wordToSearchFor);
     }
 };


### PR DESCRIPTION
Searching with grammar has the side effect of not allowing searches in module documentations, or in language variants. E.g. if you are writing a Python script which uses Numpy, you cannot search _python cumsum_ you do not find a result because you are searching the wrong documentation.